### PR TITLE
Circular deps fix

### DIFF
--- a/lib/extractors/beforeBeforeIndex.js
+++ b/lib/extractors/beforeBeforeIndex.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { beforeIndex } = require('../extractors')
+// const { beforeIndex } = require('../extractors')
 
 module.exports = () => {
-  beforeIndex()
+  // beforeIndex()
   console.log('before, before index')
 }

--- a/lib/extractors/beforeIndexTuple.js
+++ b/lib/extractors/beforeIndexTuple.js
@@ -1,0 +1,7 @@
+const beforeBeforeIndex = require('./beforeBeforeIndex')
+const beforeIndex = require('./beforeIndex')
+
+module.exports = {
+  beforeBeforeIndex,
+  beforeIndex
+}

--- a/lib/extractors/freakShow.js
+++ b/lib/extractors/freakShow.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const { beforeBeforeIndex, beforeIndex } = require('../extractors')
+const { beforeBeforeIndex, beforeIndex } = require('../extractors/beforeIndexTuple')
+// const beforeIndex = require('./beforeIndex' );
+// const beforeBeforeIndex = require( './beforeBeforeIndex' );
 
 module.exports = () => {
   console.log('freakshow', beforeBeforeIndex(), beforeIndex())


### PR DESCRIPTION
`extractors/index` requires `freakshow`, but `freakshow` requires `extractors/index`

Added a second module that holds the other modules and have `freakshow` require that.